### PR TITLE
Mbaraniak/GitHub action pinning

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [10.x, 12.x, 13.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install


### PR DESCRIPTION
  ## 📝 Summary

  
  This PR pins third-party GitHub Actions to full commit SHAs.
  Internal `ExodusMovement/...` actions are out of scope for this campaign and are intentionally not locked in these changes.
  This removes floating action references and reduces supply-chain risk by ensuring workflow execution uses reviewed, immutable upstream revisions instead of tags that can be moved.