### PR TITLE
security: bump @exodus/ripple-address-codec to ^4.2.0-alpha0.0 (CVE-2025-27611, root-cause)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@exodus/ripple-address-codec": "^4.1.1-alpha0",
+    "@exodus/ripple-address-codec": "^4.2.0-alpha0.0",
     "bn.js": "^5.1.1",
     "create-hash": "^1.2.0",
     "decimal.js": "7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,13 +94,47 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@exodus/ripple-address-codec@^4.1.1-alpha0":
-  version "4.1.1-alpha0"
-  resolved "https://registry.yarnpkg.com/@exodus/ripple-address-codec/-/ripple-address-codec-4.1.1-alpha0.tgz#3ff9c77380be184826f850c886a82322be424a51"
-  integrity sha512-/T5yV9lxtWln5ZvcySEuHBGnv5DEDmpK2r7G+ylQzzUK04O6xzy0PdbPA34LriKSD9BN+Eh6H38oe8ONejAGdA==
+"@exodus/bytes@^1.0.0-rc.4":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.1.tgz#b13bc464ca162c17abf0837fb3a11aeab79e45d1"
+  integrity sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==
+
+"@exodus/crypto@^1.0.0-rc.20":
+  version "1.0.0-rc.34"
+  resolved "https://registry.yarnpkg.com/@exodus/crypto/-/crypto-1.0.0-rc.34.tgz#eec87df3d4fea77821657ab52836b1378f2a1428"
+  integrity sha512-vatlfAs8fBJ7drzM1uRtN4y8Q6CZix6sDwRSyuTMPzPFYWo97Fw/no3yztiVBPtaoXnG57+hpiXu3diltOGsfg==
   dependencies:
-    base-x "3.0.4"
-    create-hash "^1.1.2"
+    "@exodus/bytes" "^1.0.0-rc.4"
+    "@noble/ciphers" "^1.2.1"
+    "@noble/curves" "^2.0.1"
+    "@noble/hashes" "^2.0.1"
+    pako "^1.0.11"
+
+"@exodus/ripple-address-codec@^4.2.0-alpha0.0":
+  version "4.2.0-alpha0.0"
+  resolved "https://registry.yarnpkg.com/@exodus/ripple-address-codec/-/ripple-address-codec-4.2.0-alpha0.0.tgz#08eae569e6f07ad75ec58c54dec4606732a299b5"
+  integrity sha512-XRXFaZRe9HTFU0W2lMrHP9f1Rw2jH2XCJ3jsbmmaGyBXqFvCjpp83XRujg1Bdvsm/4YyiP+olXAF7AiFtqdvcQ==
+  dependencies:
+    "@exodus/crypto" "^1.0.0-rc.20"
+    base-x "^3.0.4"
+    minimalistic-assert "^1.0.1"
+
+"@noble/ciphers@^1.2.1":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
+"@noble/curves@^2.0.1":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-2.2.0.tgz#981be3aadc3bbfbcdb245e78cc97aa6f759246c2"
+  integrity sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==
+  dependencies:
+    "@noble/hashes" "2.2.0"
+
+"@noble/hashes@2.2.0", "@noble/hashes@^2.0.1":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.2.0.tgz#22da1d16a469954fce877055d559900a6c73b63b"
+  integrity sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -793,10 +827,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-x@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
-  integrity sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==
+base-x@^3.0.4:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.11.tgz#40d80e2a1aeacba29792ccc6c5354806421287ff"
+  integrity sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==
   dependencies:
     safe-buffer "^5.0.1"
 
@@ -1108,7 +1142,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-create-hash@^1.1.2, create-hash@^1.2.0:
+create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
@@ -2442,6 +2476,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
 "minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -2796,6 +2835,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## What
Bumps `@exodus/ripple-address-codec` from `^4.1.1-alpha0` → **`^4.2.0-alpha0.0`** (already published), and regenerates `yarn.lock`. This re-resolves transitive **base-x** `3.0.4 → 3.0.11`. Clears this repo's Dependabot alert **#39** (GHSA-xq7p-g2vc-g82p / CVE-2025-27611, CWE-1007).

## Why this is the root-cause fix
`^4.1.1-alpha0` resolves to the **stale** published `ripple-address-codec@4.1.1-alpha0`, which **hard-pins `base-x@3.0.4`** (exact). base-x `<=3.0.10` lets a Unicode homoglyph (`charCodeAt > 255`) bypass the "Non-base58 character" guard and **silently decode to wrong bytes** instead of throwing.

The already-published `ripple-address-codec@4.2.0-alpha0.0` declares `base-x: ^3.0.4` (→ 3.0.11). The newer version didn't get picked up only because of semver **prerelease-range** rules (`4.2.0-alpha0.0` doesn't satisfy `^4.1.1-alpha0`).

This package is the **upstream source** of the same `base-x@3.0.4` pin in `assets`, the wallets, and `magnifier` (they pull it transitively through `ripple-binary-codec`). Once this is republished, those consumers re-resolve to patched base-x **without per-repo `resolutions` overrides**.

## Validation
`yarn test` → **971 passing**, 0 failing. Diff is confined to the rac subtree (rac 4.2 modernized its crypto deps to `@exodus/crypto`/`@noble/*`) + base-x. Aligns this repo with the rac version the rest of the org's workspace already uses.

## Follow-up
`^4.2.0-alpha0.0` is itself a prerelease-caret range — the same fragility that caused this. Longer term, `ripple-address-codec` should publish **stable** releases so consumers use plain `^4` ranges.