### PR TITLE
chore: release 0.2.9 (publish the base-x CVE-2025-27611 fix from #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/ripple-binary-codec",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "XRP Ledger binary codec",
   "files": [
     "distrib/npm/*"


### PR DESCRIPTION
## What
Bumps `version` **0.2.8 → 0.2.9** so the base-x security fix can actually ship to npm.

## Why
#5 merged the real fix on `exodus` — `@exodus/ripple-address-codec` `^4.1.1-alpha0 → ^4.2.0-alpha0.0`, which re-resolves transitive **base-x** to `3.0.11` instead of the vulnerable `3.0.4` (CVE-2025-27611 / GHSA-xq7p-g2vc-g82p, CWE-1007). But #5 didn't bump the package version, so `@exodus/ripple-binary-codec` on npm is still **0.2.8** (the unfixed one). Until a new version is published, nothing downstream can pick up the fix.

## Publish step (manual — no auto-publish workflow here)
After merge, release with `npm publish` (the `prepublish` script runs test + lint + compile of `distrib/npm/*`) — same manual flow used for 0.2.7/0.2.8 (no release tags/workflow exist).

## Downstream impact
Once **0.2.9** is on npm, the consumers that pull `base-x@3.0.4` *through* this package — `assets` (#121), `exodus-mobile` (#260), `exodus-desktop` (#156), `magnifier` (#148), `exodus-hydra` (#178) — can re-resolve to `0.2.9` and drop the vulnerable base-x. (Those repos also pull it via `@exodus/ripple-lib`, which needs the same `rac` bump + release separately.)