### PR TITLE
fix: drop module.exports text from index.js comment to satisfy consumer esm/cjs fences (0.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/ripple-binary-codec",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "XRP Ledger binary codec",
   "type": "module",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -72,11 +72,11 @@ export {
   decodeLedgerData
 };
 
-// Preserve the CommonJS `module.exports = { ... }` shape as the ESM default
-// export, so existing default-import consumers (e.g. `@exodus/ripple-lib`'s
-// sign paths and `hw-ledger`, which do `import binaryCodec from
-// '@exodus/ripple-binary-codec'` then call `binaryCodec.encode(...)`) keep
-// working. Named exports above cover `import { encode } from ...` consumers.
+// Mirror the legacy CommonJS default-object shape as the ESM default export,
+// so existing default-import consumers (e.g. `@exodus/ripple-lib`'s sign paths
+// and `hw-ledger`, which do `import binaryCodec from '@exodus/ripple-binary-codec'`
+// then call `binaryCodec.encode(...)`) keep working. Named exports above cover
+// `import { encode } from ...` consumers.
 export default {
   decode,
   encode,


### PR DESCRIPTION
## Summary

`src/index.js` is pure ESM (only `import` / `export {}` / `export default {}`), but its default-export explanatory comment contained the literal text `module.exports = { ... }`.

Consumers with a **naive, regex-based (non-AST) ESM/CJS build fence** match on that text. Specifically, exodus-desktop's `scripts/build/fencing/common.mjs` rejects any file containing **both** an `import` **and** a `module.exports` / `exports[.=,]` match — so it matched the string *inside the comment* and failed the webpack build with `mixed esm/cjs code in .../@exodus/ripple-binary-codec/src/index.js!`, even though nothing is actually mixed.

## Fix

Reworded the comment to drop the literal `module.exports` string. **No code or behaviour change** — named + default exports are identical. Bumped to **0.3.1**.

Fixes the build break reported in ExodusMovement/exodus-desktop#19592.
