### PR TITLE
fix: import enums definitions as an ESM .js module (drop JSON import attribute) — 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/ripple-binary-codec",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "XRP Ledger binary codec",
   "type": "module",
   "files": [

--- a/src/enums/definitions.js
+++ b/src/enums/definitions.js
@@ -1,4 +1,6 @@
-{
+// XRP binary codec definitions, inlined as an ESM data module so consumers with
+// older bundlers (e.g. webpack 4) can parse it without a JSON import attribute.
+export default {
   "TYPES": {
     "Validation": 10003,
     "Done": -1,

--- a/src/enums/index.js
+++ b/src/enums/index.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import _ from 'lodash';
 import {parseBytes, serializeUIntN} from './../utils/bytes-utils.js';
 import makeClass from './../utils/make-class.js';
-import enums from './definitions.json' with { type: 'json' };
+import enums from './definitions.js';
 
 function transformWith(func, obj) {
   return _.transform(obj, func);


### PR DESCRIPTION
## Summary

`src/enums/index.js` imported the codec definitions with a JSON **import attribute**:

```js
import enums from './definitions.json' with { type: 'json' };
```

That `with { type: 'json' }` syntax is ES2023+. Node ESM (`nodenext`) requires it for JSON imports, but **older bundlers can't parse it** — exodus-desktop's **webpack 4.15.1** fails the build with `Module parse failed: Unexpected token`. It was the only JSON import attribute in the package.

## Fix

Inlined the definitions into **`src/enums/definitions.js`** as a plain ESM data module (`export default { ... }`), imported without an attribute:

```js
import enums from './definitions.js';
```

- **Byte-identical data** — verified the `definitions.js` default export deep-equals the former `definitions.json` (this is a codec; the data must not change).
- Parseable by **Node ESM and old bundlers** (webpack 4, Metro) alike — no import attribute, no `import.meta`.
- No API or behaviour change. Bumped to **0.3.2**.

Fixes the desktop webpack build reported in ExodusMovement/exodus-desktop#19592.
